### PR TITLE
Fix Linux builds

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,39 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  build-native:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu, windows, macos]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: "*nix: Install Qt"
+      uses: jurplel/install-qt-action@v2
+      if: matrix.os != 'windows'
+    - name: "Windows: Install Qt"
+      uses: jurplel/install-qt-action@v2
+      if: matrix.os == 'windows'
+      with:
+        arch: win64_mingw73
+    - name: Build
+      run: |
+        qmake
+        make
+    - name: "*nix: Stash"
+      if: matrix.os != 'windows'
+      uses: actions/upload-artifact@v1
+      with:
+        name: GbaWadUtil-${{ matrix.os }}
+        path: GbaWadUtil
+    - name: "Windows: Stash"
+      if: matrix.os == 'windows'
+      uses: actions/upload-artifact@v1
+      with:
+        name: GbaWadUtil-${{ matrix.os }}
+        path: release/GbaWadUtil.exe
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 
 *.user
+*.o
+.qmake.stash
+.vscode/settings.json
+GbaWadUtil
+Makefile
+moc_*.h
+moc_*.cpp

--- a/doomtypes.h
+++ b/doomtypes.h
@@ -21,7 +21,7 @@ inline static int D_abs(fixed_t x)
 inline static fixed_t FixedDiv(fixed_t a, fixed_t b)
 {
   return ((unsigned)D_abs(a)>>14) >= (unsigned)D_abs(b) ? ((a^b)>>31) ^ INT_MAX :
-    (fixed_t)(((__int64) a << FRACBITS) / b);
+    (fixed_t)(((qint64) a << FRACBITS) / b);
 }
 
 //*************************************************************************************

--- a/wadprocessor.cpp
+++ b/wadprocessor.cpp
@@ -102,7 +102,7 @@ bool WadProcessor::ProcessVertexes(quint32 lumpNum)
     vertex_t* newVtx = new vertex_t[vtxCount];
     const mapvertex_t* oldVtx = reinterpret_cast<const mapvertex_t*>(vxl.data.constData());
 
-    for(int i = 0; i < vtxCount; i++)
+    for(quint32 i = 0; i < vtxCount; i++)
     {
         newVtx[i].x = (oldVtx[i].x << 16);
         newVtx[i].y = (oldVtx[i].y << 16);
@@ -365,7 +365,10 @@ int WadProcessor::GetTextureNumForName(const char* tex_name)
     strncpy(tex_name_upper, tex_name, 8);
     tex_name_upper[8] = 0; //Ensure null terminated.
 
-    strupr(tex_name_upper);
+    for (int i = 0; i < 8; i++)
+    {
+        tex_name_upper[i] = toupper(tex_name_upper[i]);
+    }
 
     Lump tex1lump;
     wadFile.GetLumpByName("TEXTURE1", tex1lump);
@@ -430,7 +433,7 @@ bool WadProcessor::ProcessPNames()
 
     QStringList pnamesUpper;
 
-    for(int i = 0; i < count; i++)
+    for(quint32 i = 0; i < count; i++)
     {
         char n[9] = {0};
         strncpy(n, &pnamesData[i*8], 8);
@@ -449,7 +452,7 @@ bool WadProcessor::ProcessPNames()
 
     char* newPnames2 = &newPnames[4]; //Start of name list.
 
-    for(int i = 0; i < count; i++)
+    for(quint32 i = 0; i < count; i++)
     {
         QByteArray pl = pnamesUpper[i].toLatin1();
 
@@ -464,11 +467,13 @@ bool WadProcessor::ProcessPNames()
     delete[] newPnames;
 
     wadFile.ReplaceLump(lumpNum, newLump);
+
+    return true;
 }
 
 bool WadProcessor::RemoveUnusedLumps()
 {
-    for(int i = 0; i < wadFile.LumpCount(); i++)
+    for(quint32 i = 0; i < wadFile.LumpCount(); i++)
     {
         Lump l;
 


### PR DESCRIPTION
Linux doesn't support `strupr`, so I replaced it with a simple for-loop. Additionally, `__int64` was used in one spot rather than `qint64`, which resulted in another build error. Finally, I changed the type of some iterators to silence some warnings.

Additionally, I set up a Continuous Integration script via GitHub Actions. Every time you push, it'll check to see if it still builds successfully on Windows, Ubuntu, and macOS.